### PR TITLE
feat: basic zustand store setup for mock todos

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,19 +1,20 @@
 import { View, FlatList } from "react-native";
-import { todos } from "../mock-data";
 import ListItem from "../components/ListItem";
 import Footer from "../components/Footer";
 import globalStyles from "../style";
+import { useTaskStore } from "../stores/task-store";
 
 export default function IndexPage() {
-  const renderItem = ({ item }: { item: (typeof todos)[0] }) => {
-    return <ListItem todo={item.todo} />;
+  const allTodos = useTaskStore((state) => state.todos);
+  const renderItem = ({ item }: { item: (typeof allTodos)[0] }) => {
+    return <ListItem todo={item} />;
   };
   return (
     <View
       style={[{ width: "90%" }, globalStyles.boxShadow]}
       className="bg-element-violet-2 h-fit rounded-md overflow-hidden"
     >
-      <FlatList data={todos} renderItem={renderItem} />
+      <FlatList data={allTodos} renderItem={renderItem} />
       <Footer />
     </View>
   );

--- a/components/CustomCheckBox.tsx
+++ b/components/CustomCheckBox.tsx
@@ -1,15 +1,24 @@
-import { View, Text } from "react-native";
 import Checkbox from "expo-checkbox";
 import { LinearGradient } from "expo-linear-gradient";
-import { useState } from "react";
+import { useTaskStore } from "../stores/task-store";
+import { Todo } from "../types/todo";
 
-export default function CustomCheckBox() {
-  const [isChecked, setIsChecked] = useState(false);
+interface CustomCheckBoxProps {
+  todo?: Todo;
+}
+
+export default function CustomCheckBox({ todo }: CustomCheckBoxProps) {
+  const setTodoStatus = useTaskStore((state) => state.setTodoStatus);
+
+  const setIsChecked = () => {
+    setTodoStatus(todo?.id);
+  };
+
   return (
     <LinearGradient
       className="rounded-xl"
       colors={
-        isChecked
+        todo?.complete
           ? ["hsl(192, 100%, 67%)", "hsl(280, 87%, 65%)"]
           : ["transparent", "transparent"]
       }
@@ -18,9 +27,9 @@ export default function CustomCheckBox() {
     >
       <Checkbox
         className="rounded-xl p-2.5"
-        value={isChecked}
+        value={todo?.complete}
         onValueChange={setIsChecked}
-        color={isChecked ? "transparent" : undefined}
+        color={todo?.complete ? "transparent" : undefined}
       />
     </LinearGradient>
   );

--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -3,19 +3,20 @@ import CustomCheckBox from "./CustomCheckBox";
 import { AntDesign } from "@expo/vector-icons";
 import CustomButton from "./CustomButton";
 import globalStyles from "../style";
+import type { Todo } from "../types/todo";
 
 interface ListItemProps {
-  todo: string;
+  todo: Todo;
 }
 
 export default function ListItem({ todo }: ListItemProps) {
   return (
     <View className="py-6 px-4 flex-row justify-between items-center border-b border-gray-500">
       <View>
-        <CustomCheckBox />
+        <CustomCheckBox todo={todo} />
       </View>
       <Text className="text-gray-300 w-3/4" style={globalStyles.fontStyle}>
-        {todo}
+        {todo.todo}
       </Text>
       <View>
         <CustomButton

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo-linking": "~4.0.1",
         "expo-router": "^1.0.0",
         "expo-status-bar": "~1.4.4",
+        "immer": "^10.0.2",
         "nativewind": "^2.0.11",
         "react": "18.2.0",
         "react-native": "0.71.8",
@@ -27,7 +28,8 @@
         "react-native-screens": "~3.20.0",
         "react-native-svg": "13.4.0",
         "react-native-web": "~0.18.10",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "zustand": "^4.3.9"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -8668,6 +8670,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -15352,6 +15363,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.9.tgz",
+      "integrity": "sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo-linking": "~4.0.1",
     "expo-router": "^1.0.0",
     "expo-status-bar": "~1.4.4",
+    "immer": "^10.0.2",
     "nativewind": "^2.0.11",
     "react": "18.2.0",
     "react-native": "0.71.8",
@@ -27,7 +28,8 @@
     "react-native-screens": "~3.20.0",
     "react-native-svg": "13.4.0",
     "react-native-web": "~0.18.10",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "zustand": "^4.3.9"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/stores/task-store.ts
+++ b/stores/task-store.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import type { State, Actions } from "../types/todo";
+import { todos as mockTodos } from "../mock-data";
+
+export const useTaskStore = create(
+  immer<State & Actions>((set) => ({
+    todos: mockTodos,
+    setTodoStatus: (id) =>
+      set((state) => {
+        state.todos = state.todos.map((item) =>
+          item.id === id ? { ...item, complete: !item.complete } : item
+        );
+      }),
+  }))
+);

--- a/types/todo.ts
+++ b/types/todo.ts
@@ -1,0 +1,13 @@
+export interface Todo {
+  id: string;
+  todo: string;
+  complete: boolean;
+}
+
+export type State = {
+  todos: Todo[];
+};
+
+export type Actions = {
+  setTodoStatus: (id: string) => void;
+};


### PR DESCRIPTION
I added zustand + immer for state management in the application with some basic setup.
I also properly typed the props for `custom-checkbox` component to be optional because we are using it in two places:
- `Input` component
- `ListItem` component

In the `Input` component, we don't pass a todo object to it, (the `Input` component -> `custom-checkbox`) so if we try to access the object inside `custom-checkbox` without checking if it exists first (optional chaining), it will return `undefined` and throw an error. I fixed this