### PR TITLE
feat: complete `add new todo` func and filtered lists on `active` and `completed` tabs

### DIFF
--- a/app/active.tsx
+++ b/app/active.tsx
@@ -3,17 +3,19 @@ import { todos } from "../mock-data";
 import ListItem from "../components/ListItem";
 import Footer from "../components/Footer";
 import globalStyles from "../style";
+import { useTaskStore } from "../stores/task-store";
 
 export default function ActivePage() {
-  const renderItem = ({ item }: { item: (typeof todos)[0] }) => {
-    return <ListItem todo={item.todo} />;
+  const activeTodos = useTaskStore((state) => state.activeTodos());
+  const renderItem = ({ item }: { item: (typeof activeTodos)[0] }) => {
+    return <ListItem todo={item} />;
   };
   return (
     <View
       style={[{ width: "90%" }, globalStyles.boxShadow]}
       className="bg-element-violet-2 h-fit rounded-md overflow-hidden"
     >
-      <FlatList data={todos} renderItem={renderItem} />
+      <FlatList data={activeTodos} renderItem={renderItem} />
       <Footer />
     </View>
   );

--- a/app/completed.tsx
+++ b/app/completed.tsx
@@ -1,19 +1,20 @@
 import { View, FlatList } from "react-native";
-import { todos } from "../mock-data";
 import ListItem from "../components/ListItem";
 import Footer from "../components/Footer";
 import globalStyles from "../style";
+import { useTaskStore } from "../stores/task-store";
 
 export default function CompletedPage() {
-  const renderItem = ({ item }: { item: (typeof todos)[0] }) => {
-    return <ListItem todo={item.todo} />;
+  const completedTodos = useTaskStore((state) => state.completedTodos());
+  const renderItem = ({ item }: { item: (typeof completedTodos)[0] }) => {
+    return <ListItem todo={item} />;
   };
   return (
     <View
       style={[{ width: "90%" }, globalStyles.boxShadow]}
       className="bg-element-violet-2 h-fit rounded-md overflow-hidden"
     >
-      <FlatList data={todos} renderItem={renderItem} />
+      <FlatList data={completedTodos} renderItem={renderItem} />
       <Footer />
     </View>
   );

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -2,9 +2,22 @@ import { View, TextInput } from "react-native";
 import { useState } from "react";
 import CustomCheckBox from "./CustomCheckBox";
 import globalStyles from "../style";
+import { useTaskStore } from "../stores/task-store";
+import { Todo } from "../types/todo";
 
 export default function Input() {
   const [task, setNewTask] = useState("");
+  const addTodo = useTaskStore((state) => state.addTodo);
+  const addNewTodo = () => {
+    if (task.trim() === "") return;
+    const newTodo: Todo = {
+      id: Math.random().toString(36),
+      todo: task,
+      complete: false,
+    };
+    addTodo(newTodo);
+    setNewTask("");
+  };
 
   return (
     <View
@@ -21,6 +34,7 @@ export default function Input() {
         onChangeText={setNewTask}
         placeholderTextColor="#9ca3af"
         placeholder="Create a new todo..."
+        onSubmitEditing={addNewTodo}
       />
     </View>
   );

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -1,22 +1,24 @@
 import { View, TextInput } from "react-native";
 import { useState } from "react";
-import CustomCheckBox from "./CustomCheckBox";
+import InputCheckBox from "./input-checkbox";
 import globalStyles from "../style";
 import { useTaskStore } from "../stores/task-store";
 import { Todo } from "../types/todo";
 
 export default function Input() {
   const [task, setNewTask] = useState("");
+  const [isTodoComplete, setIsTodoComplete] = useState(false);
   const addTodo = useTaskStore((state) => state.addTodo);
   const addNewTodo = () => {
     if (task.trim() === "") return;
     const newTodo: Todo = {
       id: Math.random().toString(36),
       todo: task,
-      complete: false,
+      complete: isTodoComplete,
     };
     addTodo(newTodo);
     setNewTask("");
+    setIsTodoComplete(false);
   };
 
   return (
@@ -25,7 +27,10 @@ export default function Input() {
       style={{ width: "85%" }}
     >
       <View style={{ flex: 0.15 }} className="items-center justify-center p-2">
-        <CustomCheckBox />
+        <InputCheckBox
+          isTodoCompleted={isTodoComplete}
+          setIsTodoCompleted={setIsTodoComplete}
+        />
       </View>
       <TextInput
         className="p-2 text-white"

--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -15,7 +15,16 @@ export default function ListItem({ todo }: ListItemProps) {
       <View>
         <CustomCheckBox todo={todo} />
       </View>
-      <Text className="text-gray-300 w-3/4" style={globalStyles.fontStyle}>
+      <Text
+        className="w-3/4"
+        style={[
+          globalStyles.fontStyle,
+          {
+            textDecorationLine: todo.complete ? "line-through" : undefined,
+            color: todo.complete ? "#9ca3af" : "#d1d5db",
+          },
+        ]}
+      >
         {todo.todo}
       </Text>
       <View>

--- a/components/input-checkbox.tsx
+++ b/components/input-checkbox.tsx
@@ -1,0 +1,32 @@
+import Checkbox from "expo-checkbox";
+import { LinearGradient } from "expo-linear-gradient";
+
+interface InputCheckBoxProps {
+  isTodoCompleted: boolean;
+  setIsTodoCompleted: (value: boolean) => void;
+}
+
+export default function InputCheckBoxProps({
+  isTodoCompleted,
+  setIsTodoCompleted,
+}: InputCheckBoxProps) {
+  return (
+    <LinearGradient
+      className="rounded-xl"
+      colors={
+        isTodoCompleted
+          ? ["hsl(192, 100%, 67%)", "hsl(280, 87%, 65%)"]
+          : ["transparent", "transparent"]
+      }
+      start={{ x: 0.0, y: 0.0 }}
+      end={{ x: 1, y: 0 }}
+    >
+      <Checkbox
+        className="rounded-xl p-2.5"
+        value={isTodoCompleted}
+        onValueChange={setIsTodoCompleted}
+        color={isTodoCompleted ? "transparent" : undefined}
+      />
+    </LinearGradient>
+  );
+}

--- a/stores/task-store.ts
+++ b/stores/task-store.ts
@@ -4,8 +4,10 @@ import type { State, Actions } from "../types/todo";
 import { todos as mockTodos } from "../mock-data";
 
 export const useTaskStore = create(
-  immer<State & Actions>((set) => ({
+  immer<State & Actions>((set, get) => ({
     todos: mockTodos,
+    activeTodos: () => get().todos.filter((item) => item.complete === false),
+    completedTodos: () => get().todos.filter((item) => item.complete === true),
     setTodoStatus: (id) =>
       set((state) => {
         state.todos = state.todos.map((item) =>

--- a/stores/task-store.ts
+++ b/stores/task-store.ts
@@ -12,5 +12,9 @@ export const useTaskStore = create(
           item.id === id ? { ...item, complete: !item.complete } : item
         );
       }),
+    addTodo: (payload) =>
+      set((state) => {
+        state.todos = [payload, ...state.todos];
+      }),
   }))
 );

--- a/types/todo.ts
+++ b/types/todo.ts
@@ -11,6 +11,8 @@ export interface Input {
 
 export type State = {
   todos: Todo[];
+  activeTodos: () => Todo[];
+  completedTodos: () => Todo[];
 };
 
 export type Actions = {

--- a/types/todo.ts
+++ b/types/todo.ts
@@ -4,10 +4,16 @@ export interface Todo {
   complete: boolean;
 }
 
+export interface Input {
+  todo: string;
+  complete: boolean;
+}
+
 export type State = {
   todos: Todo[];
 };
 
 export type Actions = {
   setTodoStatus: (id: string) => void;
+  addTodo: (payload: Todo) => void;
 };


### PR DESCRIPTION
I added the following features:
- add new todo
- render filtered lists on `active` and `completed` views
- change todo text styles on toggle of the checkbox (completed todos -> `strikethrough` and darker text styles)